### PR TITLE
add option to normalize waveforms b4 spectrograms

### DIFF
--- a/example_config.yaml
+++ b/example_config.yaml
@@ -24,6 +24,7 @@ sgramParams:
       winLen_Sec: 1 # window length in seconds
       fracOverlap: 0.25 # window overlap fraction
       nfft: 2000  # padding # isnt this supposed to be a power of 2 ?
+      norm_waveforms: True
 
 #sgramType: "scalogram" # if you are using wavelets
 # other wavelet-specific parameters

--- a/scripts/2_convertToSpectrograms.py
+++ b/scripts/2_convertToSpectrograms.py
@@ -54,6 +54,7 @@ if __name__ == "__main__":
     # get sgram params
     fmin = config_sgram['fmin']
     fmax = config_sgram['fmax']
+    norm_waveforms = config_sgram["norm_waveforms"]
     winLen_Sec = config_sgram['winLen_Sec']
     fracOverlap = config_sgram['fracOverlap']
     nfft = config_sgram['nfft']
@@ -66,7 +67,9 @@ if __name__ == "__main__":
                         fracOverlap,
                         nfft,
                         fmin,
-                        fmax)
+                        fmax,
+                        norm_waveforms=norm_waveforms
+    )
 
     # pad short spectrograms with zeros
 

--- a/scripts/calculate_energy.py
+++ b/scripts/calculate_energy.py
@@ -8,6 +8,7 @@ import h5py
 import yaml
 
 from specufex_processing.preprocessing.energy import waveform_energy
+from specufex_processing.utils import _overwrite_group_if_exists
 
 parser = argparse.ArgumentParser()
 parser.add_argument("config_filename", help="Path to configuration file.")
@@ -34,9 +35,9 @@ dataH5_path = os.path.join(projectPath,'H5files/', dataH5_name)
 
 with h5py.File(dataH5_path,'a') as h5file:
 
-    energy_group = h5file.create_group("energy")
+    energy_group = _overwrite_group_if_exists(h5file, "energy")
     energy_channel_grp = h5file.create_group(f"energy/{station}/{channel}")
-    entropy_group = h5file.create_group("entropy")
+    entropy_group = _overwrite_group_if_exists(h5file, "entropy")
     entropy_channel_grp = h5file.create_group(f"entropy/{station}/{channel}")
 
     evIDs = list(h5file["waveforms"][station][channel].keys())

--- a/specufex_processing/preprocessing/spectrogram.py
+++ b/specufex_processing/preprocessing/spectrogram.py
@@ -24,7 +24,7 @@ class SpectrogramMaker:
         self.fmin = fmin
         self.fmax = fmax
 
-    def __call__(self, waveform):
+    def __call__(self, waveform, normalize=True):
         """Converts a waveform into a transformed spectrogram
         Returns
         -------
@@ -33,6 +33,11 @@ class SpectrogramMaker:
             STFT_0 - the original, non-transformed spectrogram
 
         """
+
+        ##### Normalize each waveform #####
+        if normalize:
+            waveform = waveform / np.abs(waveform).max()
+
         fSTFT, tSTFT, STFT_raw = spectrogram(waveform,fs=self.fs,nperseg=self.nperseg,
                                             noverlap=self.noverlap,nfft=self.nfft,
                                             scaling=self.scaling,axis=-1,mode=self.mode)
@@ -101,6 +106,7 @@ def create_spectrograms(
     nfft,
     fmin,
     fmax,
+    norm_waveforms=True
 ):
     """Create spectrograms from h5 file
     """
@@ -123,10 +129,17 @@ def create_spectrograms(
         mode='magnitude'
         scaling='spectrum'
 
-        spectmaker = SpectrogramMaker(fs=fs,nperseg=nperseg,
-                            noverlap=noverlap,nfft=nfft,
-                            mode=mode,scaling=scaling,
-                            trim=True,fmin=fmin,fmax=fmax)
+        spectmaker = SpectrogramMaker(
+            fs=fs,
+            nperseg=nperseg,
+            noverlap=noverlap,
+            nfft=nfft,
+            mode=mode,
+            scaling=scaling,
+            trim=True,
+            fmin=fmin,
+            fmax=fmax,
+            norm_waveforms=norm_waveforms)
 
         badevIDs = []
         evIDs = []


### PR DESCRIPTION
can now select whether or not to normalize the original waveforms before creating the spectrograms